### PR TITLE
fix:port code to 3.6 and 3.7 python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,27 @@ from setuptools import find_packages, setup
 with open('README.rst') as f:
     long_description = f.read()
 
+
+requires = [
+    'ijson>=2.5',
+    'jsonref',
+    'jsonpointer',
+    'xlsxwriter',
+    'requests',
+    'click',
+    'dataclasses;python_version<"3.7"'
+]
+test_requires = [
+    'pytest',
+    'pytest-cov',
+    'coveralls'
+] + requires
+docs_requires = [
+    'Sphinx',
+    'sphinx-autobuild',
+    'sphinx-rtd-theme',
+]
+
 setup(
     name='spoonbill',
     version='0.0.1',
@@ -13,33 +34,22 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests', 'tests.*']),
     long_description=long_description,
-    install_requires=[
-        'ijson>=2.5',
-        'jsonref',
-        'xlsxwriter',
-        'requests',
-        'click',        
-    ],
+    install_requires=requires,
     extras_require={
-        'test': [
-            'pytest',
-            'pytest-cov',
-            'coveralls',
-        ],
-        'docs': [
-            'Sphinx',
-            'sphinx-autobuild',
-            'sphinx-rtd-theme',
-        ],
+        'test': test_requires,
+        'docs': docs_requires,
     },
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        # 'Programming Language :: Python :: 3.6',
-        # 'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
     entry_points={
+        'console_scripts': [
+            'spoonbill = spoonbill.cli:cli'
+        ]
     }
 )

--- a/spoonbill/flatten.py
+++ b/spoonbill/flatten.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, is_dataclass, field
-from collections.abc import Mapping, Sequence
+from typing import Mapping, Sequence
 from collections import defaultdict, deque
 from pathlib import Path
 
@@ -84,7 +84,8 @@ class Flattener:
             while to_flatten:
                 abs_path, path, parent_key, parent, record = to_flatten.pop()
                 # Strict match /tender /parties etc., so this is a new row
-                if table := self._path_cache.get(path):
+                table = self._path_cache.get(path)
+                if table:
                     row_id = generate_row_id(ocid,
                                              record.get('id', ''),
                                              parent_key,

--- a/spoonbill/spec.py
+++ b/spoonbill/spec.py
@@ -1,7 +1,6 @@
 import logging
 from collections import OrderedDict
-from typing import List
-from collections.abc import Mapping, Sequence
+from typing import Mapping, Sequence, List
 from dataclasses import dataclass, field, is_dataclass
 
 from spoonbill.utils import get_root, combine_path, prepare_title, generate_table_name
@@ -26,10 +25,10 @@ class Table:
     parent: object = field(default_factory=dict)
     is_root: bool = False
     is_combined: bool = False
-    columns: OrderedDict[str, Column] = field(default_factory=OrderedDict)
-    combined_columns: OrderedDict[str, Column] = field(default_factory=OrderedDict)
-    propagated_columns: OrderedDict[str, Column] = field(default_factory=OrderedDict)
-    additional_columns: OrderedDict[str, Column] = field(default_factory=OrderedDict)
+    columns: Mapping[str, Column] = field(default_factory=OrderedDict)
+    combined_columns: Mapping[str, Column] = field(default_factory=OrderedDict)
+    propagated_columns: Mapping[str, Column] = field(default_factory=OrderedDict)
+    additional_columns: Mapping[str, Column] = field(default_factory=OrderedDict)
     # max length not count
     arrays: Mapping[str, int] = field(default_factory=dict)
     # for headers
@@ -43,7 +42,8 @@ class Table:
     def __post_init__(self):
         for attr in ('columns', 'propagated_columns',
                      'combined_columns', 'additional_columns'):
-            if obj := getattr(self, attr, {}):
+            obj = getattr(self, attr, {})
+            if obj:
                 init = {name: Column(**col) for name, col in obj.items() if not is_dataclass(col)}
                 setattr(self, attr, init)
 

--- a/spoonbill/stats.py
+++ b/spoonbill/stats.py
@@ -1,7 +1,6 @@
 import json
 import logging
-from typing import List
-from collections.abc import Mapping
+from typing import List, Mapping
 from collections import deque
 from dataclasses import dataclass, field, asdict
 
@@ -70,7 +69,8 @@ class DataPreprocessor:
             if prop.get('deprecated'):
                 continue
             # TODO: handle oneOf anyOf allOf
-            if properties := prop.get('properties', {}):
+            properties = prop.get('properties', {})
+            if properties:
                 for key, item in properties.items():
                     if item.get('deprecated'):
                         continue
@@ -146,7 +146,8 @@ class DataPreprocessor:
 
             while to_analyze:
                 abs_path, path, parent_key, parent, record = to_analyze.pop()
-                if table := self._table_by_path.get(path):
+                table = self._table_by_path.get(path)
+                if table:
                     table.inc()
                     for col_name in DEFAULT_FIELDS:
                         table.inc_column(col_name)
@@ -177,7 +178,6 @@ class DataPreprocessor:
                         continue
 
                     if isinstance(item, dict):
-
                         to_analyze.append((separator.join([abs_path, key]),
                                            pointer,
                                            key,

--- a/spoonbill/utils.py
+++ b/spoonbill/utils.py
@@ -53,7 +53,8 @@ def validate_type(type_, item):
     True
     """
     name = type(item).__name__
-    if expected := _PYTHON_TO_JSON_TYPE.get(name):
+    expected = _PYTHON_TO_JSON_TYPE.get(name)
+    if expected:
         return expected in type_
     return True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist=
+    py{36,37,38,39},
+
+[testenv]
+deps = .[test]
+commands =
+	pytest --cov-report=term-missing --cov=spoonbill --doctest-modules --ignore=docs .


### PR DESCRIPTION
1. Port to 3.6, 3.7
2. Include tox.ini to run tests on different python versions