### PR TITLE
fix: set configuring writers from options not tables

### DIFF
--- a/spoonbill/writers/csv.py
+++ b/spoonbill/writers/csv.py
@@ -27,14 +27,13 @@ class CSVWriter:
         self.tables = tables
         self.options = options
         self.headers = {}
-        for name, table in self.tables.items():
-            opt = self.options.selection[name]
-            headers = get_headers(table, opt)
-            self.headers[name] = headers
-            fd = open(workdir / f"{name}.csv", "w")
+        for table_key, opt in self.options.selection.items():
+            headers = get_headers(tables[table_key], opt)
+            self.headers[table_key] = headers
+            fd = open(workdir / f"{table_key}.csv", "w")
             writer = csv.DictWriter(fd, headers)
             self.fds.append(fd)
-            self.writers[name] = writer
+            self.writers[table_key] = writer
 
     def writeheaders(self):
         """Write headers to output file"""

--- a/spoonbill/writers/xlsx.py
+++ b/spoonbill/writers/xlsx.py
@@ -34,20 +34,19 @@ class XlsxWriter:
 
     def writeheaders(self):
         """Write headers to output file"""
-        for name, table in self.tables.items():
-            opt = self.options.selection[name]
+        for table_key, opt in self.self.options.selection.items():
             split = opt.split
-            sheet = self.workbook.add_worksheet(name)
-            headers = get_headers(table, opt)
+            sheet = self.workbook.add_worksheet(table_key)
+            headers = get_headers(self.tables[table_key], opt)
             for col_index, col_name in enumerate(headers):
-                self.col_index[name][col_name] = col_index
+                self.col_index[table_key][col_name] = col_index
                 try:
                     sheet.write(0, col_index, headers[col_name])
                 except XlsxWriterException as err:
                     LOGGER.error(_("Failed to write header {} to xlsx sheet {} with error {}").format(
-                        col_name, name, err
+                        col_name, table_key, err
                     ))
-            self.row_counters[name] = 1
+            self.row_counters[table_key] = 1
 
     def writerow(self, table, row):
         """Write row to output file"""


### PR DESCRIPTION
Set configuring writers from options, not tables, because tables will be always more (since they are from spec object) than tables in `option.selection`