### PR TITLE
perf: Add lru_cache for common_prefix, and compare len() instead of using min() and max()

### DIFF
--- a/spoonbill/utils.py
+++ b/spoonbill/utils.py
@@ -1,4 +1,5 @@
 import codecs
+import functools
 import json
 import logging
 from collections import OrderedDict
@@ -31,6 +32,7 @@ ABBREVIATION_TABLE_NAME = {
 }
 
 
+@functools.lru_cache(maxsize=None)
 def common_prefix(path, subpath, separator="/"):
     """Given two paths, returns the longest common sub-path.
 
@@ -44,13 +46,16 @@ def common_prefix(path, subpath, separator="/"):
     '/tender/items/0'
     """
     paths = [path.split(separator), subpath.split(separator)]
-    s1 = min(paths)
-    s2 = max(paths)
-    common = s1
+    if len(paths[0]) <= len(paths[1]):
+        s1, s2 = paths
+    else:
+        s2, s1 = paths
     for i, path in enumerate(s1):
         if path != s2[i]:
             common = s1[:i]
             break
+    else:
+        common = s1
     return separator.join(common)
 
 


### PR DESCRIPTION
`common_prefix` is responsible for about 10% of running time, just on its own.

Using `lru_cache(maxsize=None)` will have an impact on memory.

I only tested with a small file and did not see a significant change in memory usage.

![AT](https://user-images.githubusercontent.com/26463/119198755-dc8bc280-ba57-11eb-8569-efdef055f7a3.png)
