### PR TITLE
Fix/cli index error issue#66

### DIFF
--- a/spoonbill/stats.py
+++ b/spoonbill/stats.py
@@ -221,7 +221,7 @@ class DataPreprocessor:
                                 item,
                             )
                         )
-                    elif isinstance(item, list):
+                    elif item and isinstance(item, list):
                         abs_pointer = separator.join([abs_path, key])
                         if not isinstance(item[0], dict) and not item_type:
                             LOGGER.warning(
@@ -310,7 +310,7 @@ class DataPreprocessor:
                                 abs_path=abs_pointer,
                             )
                         self.current_table.inc_column(abs_pointer, pointer)
-                        if with_preview and count < PREVIEW_ROWS:
+                        if item and with_preview and count < PREVIEW_ROWS:
                             self.current_table.set_preview_path(abs_pointer, pointer, item, self.table_threshold)
             yield count
         self.total_items = count

--- a/tests/data/empty_list.json
+++ b/tests/data/empty_list.json
@@ -1,0 +1,72 @@
+{
+  "uri": "",
+  "license": "gibberish",
+  "publicationPolicy": "gibberish",
+  "publishedDate": "",
+  "version": "1.1",
+  "releases": [
+    {
+      "initiationType": "tender",
+      "parties": [
+
+      ],
+      "tag": [
+        "tenderUpdate"
+      ],
+      "date": "2020-04-28T15:30:00Z",
+      "ocid": "ocds-gibber-111111",
+      "id": "aclar_gibber-111111-0",
+      "tender": {
+        "id": "111111",
+        "hasEnquiries": true,
+        "submissionMethod": [
+          "electronicSubmission"
+        ],
+        "procurementMethodDetails": "Gibberish",
+        "procurementMethod": "open",
+        "title": "Gibberish",
+        "description": "Gibberish",
+        "tenderPeriod": {
+          "endDate": "2020-05-05T12:00:00Z",
+          "startDate": "2020-04-28T15:30:00Z"
+        },
+        "procuringEntity": {
+          "id": "12-1",
+          "name": "Gibberish"
+        },
+        "submissionMethodDetails": "Gibberish",
+        "items": [
+          {
+            "id": "1",
+            "description": "Gibberish",
+            "quantity": 4800.0,
+            "classification": {
+              "id": "3711",
+              "description": "Gibberish",
+              "scheme": "Gibberish"
+            },
+            "unit": {
+              "name": "Gibberish",
+              "id": "22"
+            }
+          }
+        ],
+        "documents": [
+          {
+            "id": "Gibberish-0",
+            "documentType": "clarifications",
+            "description": "Gibberish",
+            "datePublished": "2020-05-05T12:01:00Z",
+            "url": "Gibberish",
+            "language": "es",
+            "format": "Gibberish"
+          }
+        ]
+      },
+      "buyer": {
+        "id": "12-1",
+        "name": "Gibberish"
+      }
+    }
+  ]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from spoonbill.cli import cli
 
 FILENAME = pathlib.Path("tests/data/ocds-sample-data.json").absolute()
+EMPTY_LIST_FILE = pathlib.Path("tests/data/empty_list.json").absolute()
 SCHEMA = pathlib.Path("tests/data/ocds-simplified-schema.json").absolute()
 ANALYZED = pathlib.Path("tests/data/analyzed.json").absolute()
 ONLY = pathlib.Path("tests/data/only").absolute()
@@ -208,3 +209,11 @@ def test_csv():
         assert "Done flattening. Flattened objects: 6" in result.output
         path = pathlib.Path("test").resolve() / "tenders.csv"
         assert path.resolve().exists()
+
+
+def test_empty_list_file():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        shutil.copyfile(EMPTY_LIST_FILE, "data.json")
+        result = runner.invoke(cli, ["data.json"])
+        assert result.exit_code == 0


### PR DESCRIPTION
Works well now

```
Detecting input file format
Input file is release package
No schema provided, using version 1__1__5
State file not supplied, going to analyze input file first
Analyze options:
 - table threshold => 5
 - language        => en
Processing file: uruguay-2020.json
  Processed 104803 objects  [###############################################################################################################################################################################]  313532474/313532474  100%
Done processing. Analyzed objects: 104804
Dumping analyzed data to '/home/andrew/PycharmProjects/spoonbill/uruguay-2020.json.analyzed.json'
Flattening file: uruguay-2020.json
Ignoring empty table contracts
Ignoring empty table planning
Going to export tables: tenders,tenders_items,awards,awards_items,parties
Processed tables:
tenders: 32043 rows
└-----tenders_items: 117308 rows
awards: 90344 rows
└-----awards_items: 199152 rows
parties: 191445 rows
Flattening input file
  Flattened 104804 objects  [#####################################################################################################################################################################################]  104804/104804  100%
Done flattening. Flattened objects: 104804

```