### PR TITLE
chore: Fix flake8 warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,8 @@
 [flake8]
 max-line-length = 119
 max-complexity = 26
-select = B,C,E,F,W,T4,B9
-# F821 global _ for localization
-ignore = E501, W291, F401, F821
+select = B,C,E,F,W,T4,B9,C90
+ignore = F821
 
 [isort]
 profile = black

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,6 @@ ignore = F821
 [isort]
 profile = black
 line_length = 119
-multi_line_output = 3
-include_trailing_comma = true
 
 [extract_messages]
 mapping_file = babel.cfg

--- a/spoonbill/__init__.py
+++ b/spoonbill/__init__.py
@@ -1,10 +1,9 @@
 import logging
-import pickle
 from pathlib import Path
 
 from spoonbill.common import COMBINED_TABLES, ROOT_TABLES, TABLE_THRESHOLD
 from spoonbill.flatten import Flattener
-from spoonbill.i18n import LOCALE, _
+from spoonbill.i18n import LOCALE
 from spoonbill.stats import DataPreprocessor
 from spoonbill.utils import iter_file
 from spoonbill.writers import CSVWriter, XlsxWriter

--- a/spoonbill/cli.py
+++ b/spoonbill/cli.py
@@ -1,6 +1,5 @@
 """cli.py - Command line interface related routines"""
 import logging
-import os
 import pathlib
 from itertools import chain
 
@@ -58,7 +57,9 @@ def get_selected_tables(base, selection):
 @click.option(
     "--schema",
     help=_(
-        "Schema file uri. This option is used to provide OCDS schema which spoonbill requires to analyze dataset. URI might be file path or HTTP link. Spoonbill will use default schema tag if not provided (requires internet connection)"
+        "Schema file uri. This option is used to provide OCDS schema which spoonbill requires to analyze dataset. URI "
+        "might be file path or HTTP link. Spoonbill will use default schema tag if not provided (requires internet "
+        "connection)"
     ),
     type=str,
 )

--- a/spoonbill/flatten.py
+++ b/spoonbill/flatten.py
@@ -1,12 +1,12 @@
 import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, field, is_dataclass
-from typing import List, Mapping, Sequence
+from typing import List, Mapping
 
 from spoonbill.common import DEFAULT_FIELDS, JOINABLE, JOINABLE_SEPARATOR
 from spoonbill.i18n import LOCALE, _
 from spoonbill.spec import Table
-from spoonbill.utils import generate_row_id, get_matching_tables, get_pointer, get_root
+from spoonbill.utils import generate_row_id, get_pointer, get_root
 
 LOGGER = logging.getLogger("spoonbill")
 
@@ -167,7 +167,8 @@ class Flattener:
                     if combined:
                         # add count columns only if table is rolled up
                         # in other way it could be frustrating
-                        # e.g. it may generate columns for whole array (/tender/items/200/additionalClassificationsCount)
+                        # e.g. it may generate columns for whole array like:
+                        # /tender/items/200/additionalClassificationsCount
                         target.add_column(
                             path,
                             "integer",

--- a/spoonbill/i18n.py
+++ b/spoonbill/i18n.py
@@ -1,7 +1,6 @@
 import gettext
 import json
 import locale
-import os
 from collections import deque
 from functools import lru_cache
 

--- a/spoonbill/stats.py
+++ b/spoonbill/stats.py
@@ -1,4 +1,3 @@
-import locale
 import logging
 import pickle
 from collections import defaultdict, deque
@@ -8,9 +7,9 @@ from typing import List, Mapping
 
 import jsonref
 
-from spoonbill.common import ARRAY, DEFAULT_FIELDS, JOINABLE, JOINABLE_SEPARATOR, TABLE_THRESHOLD
-from spoonbill.i18n import DOMAIN, LOCALE, LOCALEDIR, _
-from spoonbill.spec import Column, Table, add_child_table
+from spoonbill.common import ARRAY, JOINABLE, JOINABLE_SEPARATOR, TABLE_THRESHOLD
+from spoonbill.i18n import LOCALE, _
+from spoonbill.spec import Table, add_child_table
 from spoonbill.utils import (
     PYTHON_TO_JSON_TYPE,
     RepeatFilter,
@@ -18,7 +17,6 @@ from spoonbill.utils import (
     generate_row_id,
     generate_table_name,
     get_matching_tables,
-    get_pointer,
     get_root,
     recalculate_headers,
     resolve_file_uri,

--- a/spoonbill/writers/csv.py
+++ b/spoonbill/writers/csv.py
@@ -1,6 +1,5 @@
 import csv
 import logging
-from collections import defaultdict
 
 from spoonbill.i18n import _
 from spoonbill.writers.base_writer import BaseWriter

--- a/spoonbill/writers/xlsx.py
+++ b/spoonbill/writers/xlsx.py
@@ -1,6 +1,5 @@
 import collections
 import logging
-from collections import defaultdict
 
 import xlsxwriter
 from xlsxwriter.exceptions import XlsxWriterException

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import json
 import pathlib
-import pickle
 from collections import OrderedDict
 from decimal import Decimal
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,6 +1,4 @@
-from collections import OrderedDict
-
-from spoonbill.spec import Column, Table, add_child_table
+from spoonbill.spec import add_child_table
 from spoonbill.utils import combine_path, get_pointer
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,14 +1,11 @@
-import pickle
-from collections import defaultdict
 from operator import attrgetter
 from unittest.mock import call, mock_open, patch
 
-import pytest
 from jmespath import search
 from jsonpointer import resolve_pointer
 
 from spoonbill.common import JOINABLE_SEPARATOR
-from spoonbill.spec import Column, Table, add_child_table
+from spoonbill.spec import Column, Table
 from spoonbill.stats import DataPreprocessor
 from spoonbill.utils import recalculate_headers
 from tests.conftest import TEST_COMBINED_TABLES, TEST_ROOT_TABLES, schema_path


### PR DESCRIPTION
Note: `ignore = F821` is shadowing an bug: `spoonbill/stats.py:227:106: F821 undefined name 'root'`
