### PR TITLE
fix: .xlsx writer `only` error handling

### DIFF
--- a/spoonbill/flatten.py
+++ b/spoonbill/flatten.py
@@ -239,6 +239,11 @@ class Flattener:
                         "parentID": parent.get("id"),
                         "ocid": ocid,
                     }
+
+                    if self.options.selection[table.name].only:
+                        only_columns = self.options.selection[table.name].only
+                        new_row = {key: new_row[key] for key in only_columns if key in new_row}
+
                     if table.is_root:
                         repeat = {}
                     if repeat:

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -284,3 +284,13 @@ def test_flatten_fields_compare(spec_analyzed, releases):
                             expected = JOINABLE_SEPARATOR.join(expected)
                         assert expected == value
                 counters[name] += 1
+
+
+def test_flatten_only_no_default_columns(spec_analyzed, releases):
+    options = FlattenOptions(**{"selection": {"tenders": {"split": True, "only": ["/tender/id"]}}})
+    flattener = Flattener(options, spec_analyzed.tables)
+    for _count, flat in flattener.flatten(releases):
+        for name, rows in flat.items():
+            for row in rows:
+                assert len(rows) == 1
+                assert "/tender/id" in row


### PR DESCRIPTION
While using `only` in selection options on web app (https://github.com/open-contracting/spoonbill-web/blob/main/core/data/ocds_lite_config.json),  writer would attempt to write values in abcent columns, thus worker would crash. Result - empty rows in tables.

```[2021-06-02 08:30:56,955: INFO/ForkPoolWorker-2] Dumping all sheets to file to file '/tmp/ca069eda-9e5f-46a8-89fb-86912494ffaa/result.xlsx'
[2021-06-02 08:30:56,955: INFO/ForkPoolWorker-2] Dumping all sheets to file to file '/tmp/ca069eda-9e5f-46a8-89fb-86912494ffaa/result.xlsx'
[2021-06-02 08:30:56,960: ERROR/ForkPoolWorker-2] Operation produced invalid path. This a software bug, please send issue to developers
[2021-06-02 08:30:56,960: ERROR/ForkPoolWorker-2] Failed to write column rowID to xlsx sheet tenders
[2021-06-02 08:30:56,960: ERROR/ForkPoolWorker-2] Operation produced invalid path. This a software bug, please send issue to developers
[2021-06-02 08:30:56,960: ERROR/ForkPoolWorker-2] Failed to write column rowID to xlsx sheet tenders
[2021-06-02 08:30:56,961: ERROR/ForkPoolWorker-2] Operation produced invalid path. This a software bug, please send issue to developers
[2021-06-02 08:30:56,961: ERROR/ForkPoolWorker-2] Failed to write column rowID to xlsx sheet tenders
```
